### PR TITLE
Seems to be a typo, should be "messages"

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A GraphQL playground is available at `/graphql`. There you have all the document
 ```graphql
 {
   transactions(
-    filter: { message: {vm_param: {add_package: {}}}}
+    filter: { messages: {vm_param: {add_package: {}}}}
   ) {
     index
     hash


### PR DESCRIPTION
This doesn't work in the graphql playground unless I change "message" to "messages".